### PR TITLE
Use ‘${R_HOME}/bin/R’ rather than just ‘R’ during testing

### DIFF
--- a/tests/testthat/test-thisfile.R
+++ b/tests/testthat/test-thisfile.R
@@ -8,7 +8,7 @@ test_that("thisfile works with source", {
 
 test_that("thisfile works with Rscript", {
   skip_on_cran()
-  p <- pipe("Rscript scripts/thisfile-cat.R")
+  p <- pipe('"$(R_HOME)/bin/Rscript" scripts/thisfile-cat.R')
   on.exit(close(p))
   res <- readLines(p)
   expect_equal("scripts/thisfile-cat.R", res[[length(res)]])
@@ -16,7 +16,7 @@ test_that("thisfile works with Rscript", {
 
 test_that("thisfile works with R", {
   skip_on_cran()
-  p <- pipe("R --slave --vanilla --no-save -f scripts/thisfile-cat.R")
+  p <- pipe('"$(R_HOME)/bin/R" --slave --vanilla --no-save -f scripts/thisfile-cat.R')
   on.exit(close(p))
   res <- readLines(p)
   expect_equal("scripts/thisfile-cat.R", res[[length(res)]])


### PR DESCRIPTION
Travis does not like R being called without full path (although tests pass locally)

```
> test_check("rprojroot")
── 1. Failure: thisfile works with Rscript (@test-thisfile.R#14)  ──────────────
"scripts/thisfile-cat.R" not equal to res[[length(res)]].
1/1 mismatches
x[1]: "scripts/thisfile-cat.R"
y[1]: "'Rscript' should not be used without a path -- see par. 1.6 of the manual
y[1]: "
```