### PR TITLE
chore: Rename `is_root()` to `is_fs_root()` to avoid confusion

### DIFF
--- a/R/root.R
+++ b/R/root.R
@@ -101,7 +101,7 @@ find_root <- function(criterion, path = ".") {
       }
     }
 
-    if (is_root(path)) {
+    if (is_fs_root(path)) {
       stop("No root directory found in ", start_path, " or its parent directories. ",
         paste(format(criterion), collapse = "\n"),
         call. = FALSE
@@ -130,7 +130,7 @@ get_start_path <- function(path, subdirs) {
 }
 
 # Borrowed from devtools
-is_root <- function(path) {
+is_fs_root <- function(path) {
   identical(
     normalizePath(path, winslash = "/"),
     normalizePath(dirname(path), winslash = "/")

--- a/tests/testthat/test-file.R
+++ b/tests/testthat/test-file.R
@@ -7,7 +7,7 @@ test_that("has_file", {
   stop_path <- hierarchy(1L)
   path <- hierarchy(4L)
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(
     find_root_file("c", criterion = "b/a", path = path),

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -53,7 +53,7 @@ test_that("has_file", {
   stop_path <- hierarchy(1L)
   path <- hierarchy(4L)
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root("a", path = path), hierarchy(3L))
   expect_equal(find_root("b", path = path), hierarchy(3L))
@@ -91,7 +91,7 @@ test_that("has_file_pattern", {
   stop_path <- hierarchy(1L)
   path <- hierarchy(4L)
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root(has_file_pattern(glob2rx("a")), path = path), hierarchy(3L))
   expect_equal(find_root(has_file_pattern(glob2rx("b")), path = path), hierarchy(3L))
@@ -135,7 +135,7 @@ test_that("has_dir", {
   stop_path <- hierarchy(1L)
   path <- hierarchy(4L)
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root(has_dir("a"), path = path), hierarchy(1L))
   expect_equal(find_root(has_dir("b"), path = path), hierarchy(2L))
@@ -160,7 +160,7 @@ test_that("has_basename", {
   stop_path <- hierarchy(1L)
   path <- hierarchy(4L)
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root(has_basename("a"), path = path), hierarchy(2L))
   expect_equal(find_root(has_basename("b"), path = path), hierarchy(3L))
@@ -187,7 +187,7 @@ test_that("concrete criteria", {
   stop_path <- hierarchy(0L)
   path <- hierarchy(4L)
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root(is_rstudio_project, path = path), hierarchy(1L))
   expect_equal(find_root(is_remake_project, path = path), hierarchy(2L))
@@ -206,7 +206,7 @@ test_that("is_svn_root", {
   stop_path <- normalizePath(tempdir(), winslash = "/")
   path <- hierarchy(4L)
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root(is_svn_root, path = path), hierarchy(1L))
   expect_equal(find_root(is_vcs_root, path = path), hierarchy(1L))
@@ -246,7 +246,7 @@ test_that("is_git_root", {
   path <- hierarchy(4L)
   stop_path <- normalizePath(tempdir(), winslash = "/")
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root(is_git_root, path = path), hierarchy(1L))
   expect_equal(find_root(is_vcs_root, path = path), hierarchy(1L))
@@ -265,7 +265,7 @@ test_that("is_git_root for separated git directory", {
   path <- hierarchy(4L)
   stop_path <- normalizePath(tempdir(), winslash = "/")
 
-  local_mocked_bindings(is_root = function(x) x == stop_path)
+  local_mocked_bindings(is_fs_root = function(x) x == stop_path)
 
   expect_equal(find_root(is_git_root, path = path), hierarchy(1L))
   expect_equal(find_root(is_vcs_root, path = path), hierarchy(1L))


### PR DESCRIPTION
From #100, CC @salim-b.