### PR TITLE
feat: Avoid warnings on Windows network drives

### DIFF
--- a/R/root.R
+++ b/R/root.R
@@ -132,8 +132,8 @@ get_start_path <- function(path, subdirs) {
 # Borrowed from devtools
 is_fs_root <- function(path) {
   identical(
-    normalizePath(path, winslash = "/"),
-    normalizePath(dirname(path), winslash = "/")
+    normalizePath(path, winslash = "/", mustWork = FALSE),
+    normalizePath(dirname(path), winslash = "/", mustWork = FALSE)
   )
 }
 


### PR DESCRIPTION
To avoid not useful warnings.

The default is NA, and warns if path doesn't exist. I see this warning when I open projects on Windows network drive.

This PR silences these warnings.
The only difference between `mustWork = NA` and `mustWork = FALSE` is the warning.