### PR TITLE
docs: Use single quotes to avoid nested double quotes

### DIFF
--- a/R/root.R
+++ b/R/root.R
@@ -232,7 +232,7 @@ has_dir <- function(filepath) {
     dir.exists(testfile)
   }))
 
-  desc <- paste0('contains a directory "', filepath, '"')
+  desc <- paste0("contains a directory '", filepath, "'")
 
   root_criterion(testfun, desc)
 }

--- a/R/root.R
+++ b/R/root.R
@@ -201,12 +201,12 @@ has_file <- function(filepath, contents = NULL, n = -1L, fixed = FALSE) {
   }))
 
   desc <- paste0(
-    'contains a file "', filepath, '"',
+    "contains a file '", filepath, "'",
     if (!is.null(contents)) {
       paste0(
         " with contents ",
         if (!fixed) "matching ",
-        '"', contents, '"',
+        "'", contents, "'",
         if (n >= 0L) paste0(" in the first ", format_lines(n))
       )
     }
@@ -273,12 +273,12 @@ has_file_pattern <- function(pattern, contents = NULL, n = -1L, fixed = FALSE) {
   }))
 
   desc <- paste0(
-    'contains a file matching "', pattern, '"',
+    "contains a file matching '", pattern, "'",
     if (!is.null(contents)) {
       paste0(
         " with contents ",
         if (!fixed) "matching ",
-        '"', contents, '"',
+        "'", contents, "'",
         if (n >= 0L) paste0(" in the first ", format_lines(n))
       )
     }

--- a/tests/testthat/_snaps/root.md
+++ b/tests/testthat/_snaps/root.md
@@ -3,14 +3,14 @@
     Code
       format(is_r_package)
     Output
-      [1] "Root criterion: contains a file \"DESCRIPTION\" with contents matching \"^Package: \""
+      [1] "Root criterion: contains a file 'DESCRIPTION' with contents matching '^Package: '"
 
 ---
 
     Code
       is_r_package
     Output
-      Root criterion: contains a file "DESCRIPTION" with contents matching "^Package: "
+      Root criterion: contains a file 'DESCRIPTION' with contents matching '^Package: '
 
 ---
 
@@ -19,7 +19,7 @@
     Output
       Root criterion: one of
       - contains a directory ".git"
-      - contains a file ".git" with contents matching "^gitdir: "
+      - contains a file '.git' with contents matching '^gitdir: '
       - contains a directory ".svn"
 
 ---
@@ -27,14 +27,14 @@
     Code
       has_file("a", contents = "foo", fixed = TRUE)
     Output
-      Root criterion: contains a file "a" with contents "foo"
+      Root criterion: contains a file 'a' with contents 'foo'
 
 ---
 
     Code
       has_file_pattern("a.*b", contents = "foo", fixed = TRUE)
     Output
-      Root criterion: contains a file matching "a.*b" with contents "foo"
+      Root criterion: contains a file matching 'a.*b' with contents 'foo'
 
 ---
 
@@ -42,39 +42,39 @@
       criteria
     Output
       $is_rstudio_project
-      Root criterion: contains a file matching "[.]Rproj$" with contents matching "^Version: " in the first line
+      Root criterion: contains a file matching '[.]Rproj$' with contents matching '^Version: ' in the first line
       
       $is_vscode_project
       Root criterion: contains a directory ".vscode"
       
       $is_r_package
-      Root criterion: contains a file "DESCRIPTION" with contents matching "^Package: "
+      Root criterion: contains a file 'DESCRIPTION' with contents matching '^Package: '
       
       $is_remake_project
-      Root criterion: contains a file "remake.yml"
+      Root criterion: contains a file 'remake.yml'
       
       $is_pkgdown_project
       Root criterion: one of
-      - contains a file "_pkgdown.yml"
-      - contains a file "_pkgdown.yaml"
-      - contains a file "pkgdown/_pkgdown.yml"
-      - contains a file "pkgdown/_pkgdown.yaml"
-      - contains a file "inst/_pkgdown.yml"
-      - contains a file "inst/_pkgdown.yaml"
+      - contains a file '_pkgdown.yml'
+      - contains a file '_pkgdown.yaml'
+      - contains a file 'pkgdown/_pkgdown.yml'
+      - contains a file 'pkgdown/_pkgdown.yaml'
+      - contains a file 'inst/_pkgdown.yml'
+      - contains a file 'inst/_pkgdown.yaml'
       
       $is_renv_project
-      Root criterion: contains a file "renv.lock" with contents matching ""Packages":\s*\{"
+      Root criterion: contains a file 'renv.lock' with contents matching '"Packages":\s*\{'
       
       $is_projectile_project
-      Root criterion: contains a file ".projectile"
+      Root criterion: contains a file '.projectile'
       
       $is_quarto_project
-      Root criterion: contains a file "_quarto.yml"
+      Root criterion: contains a file '_quarto.yml'
       
       $is_git_root
       Root criterion: one of
       - contains a directory ".git"
-      - contains a file ".git" with contents matching "^gitdir: "
+      - contains a file '.git' with contents matching '^gitdir: '
       
       $is_svn_root
       Root criterion: contains a directory ".svn"
@@ -82,7 +82,7 @@
       $is_vcs_root
       Root criterion: one of
       - contains a directory ".git"
-      - contains a file ".git" with contents matching "^gitdir: "
+      - contains a file '.git' with contents matching '^gitdir: '
       - contains a directory ".svn"
       
       $is_testthat
@@ -100,17 +100,17 @@
       str(criteria)
     Output
       List of 13
-       $ is_rstudio_project   : chr "Root criterion: contains a file matching \"[.]Rproj$\" with contents matching \"^Version: \" in the first line"
+       $ is_rstudio_project   : chr "Root criterion: contains a file matching '[.]Rproj$' with contents matching '^Version: ' in the first line"
        $ is_vscode_project    : chr "Root criterion: contains a directory \".vscode\""
-       $ is_r_package         : chr "Root criterion: contains a file \"DESCRIPTION\" with contents matching \"^Package: \""
-       $ is_remake_project    : chr "Root criterion: contains a file \"remake.yml\""
-       $ is_pkgdown_project   : chr [1:7] "Root criterion: one of" "- contains a file \"_pkgdown.yml\"" "- contains a file \"_pkgdown.yaml\"" "- contains a file \"pkgdown/_pkgdown.yml\"" ...
-       $ is_renv_project      : chr "Root criterion: contains a file \"renv.lock\" with contents matching \"\"Packages\":\\s*\\{\""
-       $ is_projectile_project: chr "Root criterion: contains a file \".projectile\""
-       $ is_quarto_project    : chr "Root criterion: contains a file \"_quarto.yml\""
-       $ is_git_root          : chr [1:3] "Root criterion: one of" "- contains a directory \".git\"" "- contains a file \".git\" with contents matching \"^gitdir: \""
+       $ is_r_package         : chr "Root criterion: contains a file 'DESCRIPTION' with contents matching '^Package: '"
+       $ is_remake_project    : chr "Root criterion: contains a file 'remake.yml'"
+       $ is_pkgdown_project   : chr [1:7] "Root criterion: one of" "- contains a file '_pkgdown.yml'" "- contains a file '_pkgdown.yaml'" "- contains a file 'pkgdown/_pkgdown.yml'" ...
+       $ is_renv_project      : chr "Root criterion: contains a file 'renv.lock' with contents matching '\"Packages\":\\s*\\{'"
+       $ is_projectile_project: chr "Root criterion: contains a file '.projectile'"
+       $ is_quarto_project    : chr "Root criterion: contains a file '_quarto.yml'"
+       $ is_git_root          : chr [1:3] "Root criterion: one of" "- contains a directory \".git\"" "- contains a file '.git' with contents matching '^gitdir: '"
        $ is_svn_root          : chr "Root criterion: contains a directory \".svn\""
-       $ is_vcs_root          : chr [1:4] "Root criterion: one of" "- contains a directory \".git\"" "- contains a file \".git\" with contents matching \"^gitdir: \"" "- contains a directory \".svn\""
+       $ is_vcs_root          : chr [1:4] "Root criterion: one of" "- contains a directory \".git\"" "- contains a file '.git' with contents matching '^gitdir: '" "- contains a directory \".svn\""
        $ is_testthat          : chr "Root criterion: directory name is \"testthat\" (also look in subdirectories: `tests/testthat`, `testthat`)"
        $ from_wd              : chr "Root criterion: from current working directory"
 
@@ -120,6 +120,13 @@
       comb_crit
     Output
       Root criterion: one of
-      - contains a file "DESCRIPTION" with contents matching "^Package: "
-      - contains a file matching "[.]Rproj$" with contents matching "^Version: " in the first line
+      - contains a file 'DESCRIPTION' with contents matching '^Package: '
+      - contains a file matching '[.]Rproj$' with contents matching '^Version: ' in the first line
+
+# is_renv_project prints regex-friendly-ish text
+
+    Code
+      is_renv_project
+    Output
+      Root criterion: contains a file 'renv.lock' with contents matching '"Packages":\s*\{'
 

--- a/tests/testthat/_snaps/root.md
+++ b/tests/testthat/_snaps/root.md
@@ -18,9 +18,9 @@
       is_vcs_root
     Output
       Root criterion: one of
-      - contains a directory ".git"
+      - contains a directory '.git'
       - contains a file '.git' with contents matching '^gitdir: '
-      - contains a directory ".svn"
+      - contains a directory '.svn'
 
 ---
 
@@ -45,7 +45,7 @@
       Root criterion: contains a file matching '[.]Rproj$' with contents matching '^Version: ' in the first line
       
       $is_vscode_project
-      Root criterion: contains a directory ".vscode"
+      Root criterion: contains a directory '.vscode'
       
       $is_r_package
       Root criterion: contains a file 'DESCRIPTION' with contents matching '^Package: '
@@ -73,17 +73,17 @@
       
       $is_git_root
       Root criterion: one of
-      - contains a directory ".git"
+      - contains a directory '.git'
       - contains a file '.git' with contents matching '^gitdir: '
       
       $is_svn_root
-      Root criterion: contains a directory ".svn"
+      Root criterion: contains a directory '.svn'
       
       $is_vcs_root
       Root criterion: one of
-      - contains a directory ".git"
+      - contains a directory '.git'
       - contains a file '.git' with contents matching '^gitdir: '
-      - contains a directory ".svn"
+      - contains a directory '.svn'
       
       $is_testthat
       Root criterion: directory name is "testthat" (also look in subdirectories: `tests/testthat`, `testthat`)
@@ -101,16 +101,16 @@
     Output
       List of 13
        $ is_rstudio_project   : chr "Root criterion: contains a file matching '[.]Rproj$' with contents matching '^Version: ' in the first line"
-       $ is_vscode_project    : chr "Root criterion: contains a directory \".vscode\""
+       $ is_vscode_project    : chr "Root criterion: contains a directory '.vscode'"
        $ is_r_package         : chr "Root criterion: contains a file 'DESCRIPTION' with contents matching '^Package: '"
        $ is_remake_project    : chr "Root criterion: contains a file 'remake.yml'"
        $ is_pkgdown_project   : chr [1:7] "Root criterion: one of" "- contains a file '_pkgdown.yml'" "- contains a file '_pkgdown.yaml'" "- contains a file 'pkgdown/_pkgdown.yml'" ...
        $ is_renv_project      : chr "Root criterion: contains a file 'renv.lock' with contents matching '\"Packages\":\\s*\\{'"
        $ is_projectile_project: chr "Root criterion: contains a file '.projectile'"
        $ is_quarto_project    : chr "Root criterion: contains a file '_quarto.yml'"
-       $ is_git_root          : chr [1:3] "Root criterion: one of" "- contains a directory \".git\"" "- contains a file '.git' with contents matching '^gitdir: '"
-       $ is_svn_root          : chr "Root criterion: contains a directory \".svn\""
-       $ is_vcs_root          : chr [1:4] "Root criterion: one of" "- contains a directory \".git\"" "- contains a file '.git' with contents matching '^gitdir: '" "- contains a directory \".svn\""
+       $ is_git_root          : chr [1:3] "Root criterion: one of" "- contains a directory '.git'" "- contains a file '.git' with contents matching '^gitdir: '"
+       $ is_svn_root          : chr "Root criterion: contains a directory '.svn'"
+       $ is_vcs_root          : chr [1:4] "Root criterion: one of" "- contains a directory '.git'" "- contains a file '.git' with contents matching '^gitdir: '" "- contains a directory '.svn'"
        $ is_testthat          : chr "Root criterion: directory name is \"testthat\" (also look in subdirectories: `tests/testthat`, `testthat`)"
        $ from_wd              : chr "Root criterion: from current working directory"
 

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -308,3 +308,10 @@ test_that("stops if depth reached", {
   # Checks that search for root terminates for very deep hierarchies
   expect_error(find_root_mocked(""), "Maximum search of [0-9]+ exceeded")
 })
+
+# The exact style of quoting here (double inside single as opposed to nested
+# double quotes) makes generating the here docs *much less fiddly*.
+# See https://github.com/r-lib/here/pull/130
+test_that("is_renv_project prints regex-friendly-ish text", {
+  expect_snapshot(is_renv_project)
+})


### PR DESCRIPTION
`is_renv_project` is the poster child for this change

Basically no amount of reasonable regex work, on the here side, leads to valid `.Rd` when you print the `desc` for the criteria, if we try to embed double quotes inside double quotes. I'm sure it's possible, but just incredibly fiddly. The problem can be designed away by using reserving double quotes for the regexes themselves (like the one used in `renv.lock`) and use single quotes to quote.