### PR TITLE
fledge: CRAN release v2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rprojroot
 Title: Finding Files in Project Subdirectories
-Version: 2.1.0.9000
+Version: 2.1.1
 Authors@R: 
     person(given = "Kirill",
            family = "M\u00fcller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,12 +6,6 @@
 
 - `is_vscode_project` looks for `.vscode/settings.json` instead of just `.vscode/` (#162, #163).
 
-## Continuous integration
-
-- Cleanup and fix macOS (#165).
-
-- Format with air, check detritus, better handling of `extra-packages` (#164).
-
 ## Documentation
 
 - Use single quotes to avoid nested double quotes (#161).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# rprojroot 2.1.0.9000 (2025-08-26)
+# rprojroot 2.1.1 (2025-08-26)
 
 ## Features
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-rprojroot 2.1.0
+rprojroot 2.1.1
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-08-26, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`