### PR TITLE
ci: Survive an archived CRAN package, cache revdep compiles

### DIFF
--- a/.github/workflows/get-website/action.yml
+++ b/.github/workflows/get-website/action.yml
@@ -1,0 +1,107 @@
+name: "Action to resolve Config/Needs/website against the configured repositories"
+inputs:
+  needs:
+    description: "The `needs` value the caller passed to the install action"
+    required: false
+    default: ""
+outputs:
+  needs:
+    description: "The `needs` value with `website` removed, once the field has been expanded here"
+    value: ${{ steps.get-website.outputs.needs }}
+  packages:
+    description: "The website packages as pak refs, with the ones no repository carries left out"
+    value: ${{ steps.get-website.outputs.packages }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve the website packages
+      # `needs: website` reaches pak as a dependency *type*
+      # (`lockfile_create(deps, dependencies = "Config/Needs/website")`),
+      # and a dependency type is resolved all-or-nothing:
+      # one entry that no repository carries fails the whole solve,
+      # before a single check runs.
+      # CRAN archives a backend from time to time --
+      # `adbi` and `RPresto` in September 2026 --
+      # and that must not take down a run that only wanted the website packages
+      # for the pkgdown reference index.
+      #
+      # No pak parameter reaches a dependency type:
+      # `?ignore-unavailable` is honoured for soft dependencies only,
+      # and `pkg=?ignore` drops the package even when it is available.
+      # So resolve the field here instead, and hand the result to pak as refs:
+      # every entry that is not a plain package name stays as it is and stays strict,
+      # every plain name the repositories carry is kept,
+      # and the rest is dropped with a warning in the job log.
+      # Nothing is removed from `DESCRIPTION`:
+      # a package that returns to CRAN is picked up again by the next run.
+      id: get-website
+      run: |
+        # `needs` is a comma- or space-separated list, the same spelling
+        # `r-lib/actions/setup-r-dependencies` accepts.
+        needs <- strsplit(trimws("${{ inputs.needs }}"), "[[:space:],]+")[[1]]
+        needs <- needs[nzchar(needs)]
+        refs <- character()
+
+        if ("website" %in% needs) {
+          needs <- setdiff(needs, "website")
+
+          # Read with read.dcf(), not `grep | cut`, for the reason `get-extra`
+          # spells out: a DCF value that wraps onto continuation lines is not
+          # what the first `grep` hit returns.
+          field <- read.dcf("DESCRIPTION", fields = "Config/Needs/website")[1, 1]
+
+          if (!is.na(field)) {
+            entries <- strsplit(trimws(gsub("[[:space:]]+", " ", field)), "[[:space:],]+")[[1]]
+            entries <- entries[nzchar(entries)]
+
+            # `setup-r` writes the RSPM repository into a user `.Rprofile`, so the
+            # repositories seen here are the ones pak resolves against. Fall back
+            # to CRAN for a local run that has no repository configured.
+            repos <- getOption("repos")
+            if (!length(repos) || any(repos == "@CRAN@")) {
+              options(repos = c(CRAN = "https://cloud.r-project.org"))
+            }
+            available <- available.packages()
+
+            # Only a plain name is looked up in a repository. An `owner/repo` or
+            # `type::ref` entry names a source of its own, and a broken one of
+            # those is a mistake in `DESCRIPTION` rather than an archival, so it
+            # keeps failing the run.
+            plain <- !grepl("[:/]", entries)
+            keep <- !plain | entries %in% rownames(available)
+
+            if (any(!keep)) {
+              cat(sprintf(
+                "::warning::Website packages left out, no configured repository carries them: %s\n",
+                paste(entries[!keep], collapse = ", ")
+              ))
+            }
+            refs <- entries[keep]
+
+            # A website package that is available can still suggest one that is
+            # not -- `duckdb` suggests the archived `adbcdrivermanager` -- and
+            # that fails the solve just as well. `pkg=?ignore-unavailable` is the
+            # parameter for exactly this case: it applies to soft dependencies,
+            # and only when the package is missing, so the dependency comes back
+            # by itself once the package does.
+            installed_base <- rownames(installed.packages(priority = "base"))
+            soft <- available[intersect(entries[keep & plain], rownames(available)), c("Suggests", "Enhances"), drop = FALSE]
+            soft <- unlist(strsplit(soft[!is.na(soft)], ","), use.names = FALSE)
+            soft <- trimws(sub("\\(.*", "", soft))
+            soft <- setdiff(unique(soft[nzchar(soft)]), c("R", installed_base, rownames(available)))
+
+            if (length(soft)) {
+              cat(sprintf(
+                "::warning::Soft dependencies of the website packages tolerated as unavailable: %s\n",
+                paste(soft, collapse = ", ")
+              ))
+              refs <- c(refs, paste0(soft, "=?ignore-unavailable"))
+            }
+          }
+        }
+
+        out <- Sys.getenv("GITHUB_OUTPUT")
+        cat("needs=", paste(needs, collapse = ","), "\n", sep = "", file = out, append = TRUE)
+        cat("packages=", paste(refs, collapse = " "), "\n", sep = "", file = out, append = TRUE)
+      shell: Rscript {0}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -128,6 +128,15 @@ runs:
       id: get-extra
       uses: ./.github/workflows/get-extra
 
+    - name: Resolve `Config/Needs/website` from DESCRIPTION
+      # Expands `needs: website` into refs, dropping the packages that CRAN has
+      # archived, so a website dependency that went away does not fail the solve
+      # for every job that asks for it. See the action for the full reasoning.
+      id: get-website
+      uses: ./.github/workflows/get-website
+      with:
+        needs: ${{ inputs.needs }}
+
     - name: Let sudo keep R library env vars (ubuntu-26.04 forbids `sudo -E`)
       # r-lib/actions/setup-r-dependencies installs pak with
       #   sudo -E --preserve-env=PATH env R -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), ...)'
@@ -153,10 +162,90 @@ runs:
         GITHUB_PAT: ${{ inputs.token }}
       with:
         pak-version: stable
-        needs: ${{ inputs.needs }}
+        needs: ${{ steps.get-website.outputs.needs }}
         packages: ${{ inputs.packages }}
-        extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }}
+        extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }} ${{ steps.get-website.outputs.packages }}
         cache-version: ${{ inputs.cache-version }}
+
+    # `Additional_repositories` is how DESCRIPTION names a repository that is
+    # not CRAN or Bioconductor, for dependencies that live outside them --
+    # a package archived from CRAN and still published elsewhere, most often.
+    # `R CMD check` reads the field to confirm such a dependency is *obtainable*
+    # (the CRAN incoming NOTE "Suggests or Enhances not in mainstream
+    # repositories" gains an "Availability using Additional_repositories
+    # specification" line), but it never installs from it, and neither does pak
+    # -- which reads `repos` alone. Without this step a package declaring the
+    # field checks against a dependency the runner does not have.
+    #
+    # The rule is narrow on purpose: a dependency is this step's business only
+    # when it is still missing after the pak solve *and* no configured
+    # repository carries it at all. That is what the field is for, and what
+    # `R CMD check` asks about. Anything CRAN still has stays with CRAN even
+    # when the additional repository also builds it -- an r-universe carries
+    # dev builds of whatever else its owner publishes, and for this package
+    # `arrow` and `nanoarrow` are in both lists, so a looser rule would swap a
+    # released dependency for a development snapshot on any runner where the
+    # first one failed to build. Folding the repository into the pak solve
+    # instead would do that everywhere.
+    #
+    # Best effort throughout. The dependencies that end up in this field are
+    # optional ones that may not build everywhere -- which is usually why they
+    # are not on CRAN -- and a package that declares one has to be written for
+    # its absence anyway (`skip_if_not_installed()`, `requireNamespace()`). So a
+    # failure here leaves the check running with one fewer optional dependency,
+    # exactly as `<package>=?ignore-build-errors` does in
+    # `Config/gha/extra-packages`, rather than failing the entry.
+    - name: Install dependencies from `Additional_repositories`
+      run: |
+        if (!file.exists("DESCRIPTION")) {
+          writeLines("No DESCRIPTION here, nothing to install.")
+          quit(save = "no")
+        }
+
+        desc <- read.dcf("DESCRIPTION")[1, ]
+        if (!("Additional_repositories" %in% names(desc))) {
+          writeLines("No `Additional_repositories` in DESCRIPTION, nothing to install.")
+          quit(save = "no")
+        }
+
+        urls <- trimws(strsplit(desc[["Additional_repositories"]], ",")[[1]])
+        urls <- urls[nzchar(urls)]
+
+        fields <- intersect(
+          c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances"),
+          names(desc)
+        )
+        deps <- unlist(strsplit(desc[fields], ","))
+        # Drop the version requirement, keeping the bare package name.
+        deps <- trimws(sub("\\(.*", "", deps))
+        deps <- setdiff(deps[nzchar(deps)], c("R", rownames(installed.packages())))
+
+        # Read the source index in both cases, the one every repository has;
+        # `install.packages()` below still picks a binary where the platform
+        # prefers one. Mirrors what `R CMD check` itself reads.
+        index <- function(repos) {
+          rownames(utils::available.packages(
+            utils::contrib.url(repos, "source"),
+            filters = c("R_version", "duplicates")
+          ))
+        }
+
+        deps <- setdiff(deps, index(getOption("repos")))
+        todo <- intersect(deps, index(urls))
+
+        writeLines(paste0("Additional repositories: ", paste(urls, collapse = ", ")))
+        writeLines(paste0(
+          "Missing dependencies no configured repository carries: ",
+          paste(todo, collapse = ", ")
+        ))
+
+        for (pkg in todo) {
+          try(utils::install.packages(pkg, repos = c(getOption("repos"), urls)))
+          writeLines(paste0(
+            pkg, " available: ", requireNamespace(pkg, quietly = TRUE)
+          ))
+        }
+      shell: Rscript {0}
 
     - name: Add pkg.lock to .gitignore
       run: |

--- a/.github/workflows/revdep4/README.md
+++ b/.github/workflows/revdep4/README.md
@@ -2,7 +2,7 @@
 
 `.github/workflows/revdep4.yaml` is built on the core in
 [`../revdepx/`](../revdepx/README.md).
-It checks every reverse dependency of igraph twice —
+It checks every reverse dependency of this package twice —
 once against the CRAN release, once against the dev version —
 inside a prebuilt universe image,
 running a package's two halves one after the other

--- a/.github/workflows/revdep4/queue.sh
+++ b/.github/workflows/revdep4/queue.sh
@@ -155,7 +155,25 @@ claimed_log=${workdir}/claimed.log
 manifest_lock=${manifest}.lock
 pkgs_dir=$(dirname -- "${manifest}")/pkgs
 
+# One compiler cache for the whole shard, handed to every check container.
+# Shard-wide rather than per package, because two packages that share a
+# LinkingTo dependency compile the same headers, and because it costs nothing
+# beyond what the halves already give: each package compiles twice here, so
+# the second half of the first package is already a hit. Under `.` like the
+# queue's own state, which no CRAN package can be named after.
+#
+# Export, because check-half.sh is a separate process; it mounts the directory
+# and does the PATH work. Set REVDEPX_CCACHE_DIR= (empty) to turn the whole
+# thing off and compile everything twice, as before.
+if [ -z "${REVDEPX_CCACHE_DIR+x}" ]; then
+  REVDEPX_CCACHE_DIR=${workdir}/.ccache
+fi
+export REVDEPX_CCACHE_DIR
+
 mkdir -p "${workdir}" "${state_dir}" "${pkgs_dir}"
+if [ -n "${REVDEPX_CCACHE_DIR}" ]; then
+  mkdir -p "${REVDEPX_CCACHE_DIR}"
+fi
 : > "${done_count}"
 : > "${fallback_count}"
 : > "${claimed_log}"
@@ -478,5 +496,13 @@ printf '{"workers":%d,"claims":%d,"completed":%d,"fallback_lines":%d,"deferred_a
   "${started_at}" "${finished_at}" > "${workdir}/queue-state.json"
 
 log "[queue] done: ${claims} claimed, ${completed} completed, ${deferred} deferred, ${fallback_lines} fallback line(s), ${worker_failures} worker death(s), $((EPOCHSECONDS - started_epoch))s"
+
+# What the compiler cache came to. `du` rather than `ccache --show-stats`,
+# because ccache lives in the check image and not on the runner; the number
+# that actually answers "did this help" is the per-half durations the run
+# already records, and this line only says the cache was there and filled.
+if [ -n "${REVDEPX_CCACHE_DIR:-}" ] && [ -d "${REVDEPX_CCACHE_DIR}" ]; then
+  log "[queue] ccache: $(du -sh "${REVDEPX_CCACHE_DIR}" 2> /dev/null | cut -f1) in ${REVDEPX_CCACHE_DIR}"
+fi
 
 exit 0

--- a/.github/workflows/revdepx/check-half.sh
+++ b/.github/workflows/revdepx/check-half.sh
@@ -89,6 +89,20 @@ forward_env=(
   _R_CHECK_TESTS_NLINES_
 )
 
+# REVDEPX_CCACHE_DIR, when set, is a host directory the caller keeps for the
+# whole shard: it is mounted as the container's CCACHE_DIR and /usr/lib/ccache
+# goes on PATH, so the compilers R CMD check invokes run through ccache.
+#
+# This is where a compiler cache has something to cache. The two halves of a
+# revdep compile the SAME sources minutes apart -- only the package under test
+# in `lib-half` differs -- and inside the container both halves see identical
+# paths, because each mounts its own workdir at the same /revdepx/out. The
+# second half therefore hits on everything that does not depend on the package
+# under test. A revdep that names it in `LinkingTo` reads headers that really
+# do differ between halves, and ccache misses on exactly those objects,
+# because what it hashes is the preprocessed source: the comparison the two
+# halves exist to make is not weakened by caching, it just stops paying twice
+# for the parts that were never different.
 half=$1
 tarball=$2
 work=$3
@@ -196,6 +210,20 @@ run_args=(
   -v "${out}/tmp:/tmp"
   -v "${lib_half}:/revdepx/lib-half:ro"
 )
+# CCACHE_MAXSIZE bounds the shard's own disk, not the Actions cache: this
+# directory lives and dies with the runner and is never uploaded.
+ccache_env=""
+if [ -n "${REVDEPX_CCACHE_DIR:-}" ]; then
+  mkdir -p "${REVDEPX_CCACHE_DIR}"
+  run_args+=(
+    -v "${REVDEPX_CCACHE_DIR}:/revdepx/ccache"
+    -e CCACHE_DIR=/revdepx/ccache
+    -e "CCACHE_MAXSIZE=${REVDEPX_CCACHE_MAXSIZE:-5G}"
+  )
+  # Single-quoted: `$PATH` is the container's, resolved by the shell in there,
+  # not this one's spliced in from the runner.
+  ccache_env='PATH=/usr/lib/ccache:$PATH '
+fi
 if [ -n "${REVDEPX_MEMORY:-}" ]; then
   run_args+=(--memory "${REVDEPX_MEMORY}" --memory-swap "${REVDEPX_MEMORY}")
 fi
@@ -217,7 +245,7 @@ done
 in_container="command -v Xvfb > /dev/null 2>&1 \
 && { Xvfb :99 -screen 0 1280x1024x24 -ac -nolisten tcp > /dev/null 2>&1 & } ; \
 DISPLAY=:99 R_LIBS='/revdepx/lib-half:${universe_lib}' TMPDIR=/tmp \
-timeout --kill-after=60s ${seconds}s \
+${ccache_env}timeout --kill-after=60s ${seconds}s \
 R CMD check --no-manual --as-cran --output=/revdepx/out \
 '/revdepx/src/${src_name}'"
 


### PR DESCRIPTION
Syncs the CI kit from cynkratemplate: https://github.com/cynkra/cynkratemplate/pull/112 and https://github.com/cynkra/cynkratemplate/pull/113, both merged. Every file here is byte-identical to the template, and the same changes are already on `main` in the 19 packages that take the kit directly.

### An archived CRAN package must not fail the dependency solve

`needs: website` reaches pak as a dependency *type* (`lockfile_create(dependencies = "Config/Needs/website")`), and a dependency type resolves all-or-nothing: one entry that no repository carries fails the whole solve, before a single check runs. That is what happened in r-dbi/DBI when CRAN archived `adbi` and `RPresto` on 2026-09-11 — every check run died in the smoke test. No pak parameter reaches inside a dependency type: `?ignore-unavailable` is honoured for soft dependencies only, and `pkg=?ignore` drops the package even when it is available. So the new `get-website` action resolves the field itself and hands pak refs instead — an `owner/repo` entry stays as it is and stays strict, a plain name the configured repositories carry is kept, and the rest is dropped with a warning in the job log. Nothing leaves `DESCRIPTION`, so a package that returns to CRAN is picked up again by the next run.

### Install an archived dependency from where it still lives

`R CMD check` reads `Additional_repositories` to confirm a dependency outside CRAN and Bioconductor is obtainable, but it never installs from it, and neither does pak, which reads `repos` alone. The new step installs a dependency only when it is still missing after the pak solve *and* no configured repository carries it at all, so anything CRAN still has stays with CRAN and a released dependency is never swapped for an r-universe development snapshot. Best effort by design: a failure leaves the check running with one fewer optional dependency, exactly as `=?ignore-build-errors` does in `Config/gha/extra-packages`.

### A shard-wide ccache for the revdep checks

Carried into the kit from https://github.com/duckdb/duckdb-r/pull/2691, where it is already running. `revdep4/queue.sh` keeps one ccache directory for the whole shard, and `revdepx/check-half.sh` mounts it into every check container with `/usr/lib/ccache` on the container's `PATH`. The two halves of a revdep compile the same sources minutes apart — only the package under test in `lib-half` differs — and both halves see identical paths inside the container, so the second half hits on everything that does not depend on the package under test, and misses on exactly the objects whose headers really do differ, because what ccache hashes is the preprocessed source. The comparison the two halves exist to make is not weakened; it just stops paying twice for the parts that were never different. `REVDEPX_CCACHE_DIR=` empty turns it off. These workflows run on a schedule and on dispatch, so this part is not exercised by this PR's own checks.

### Effect here

None today. `Config/Needs/website` in this package holds only the `tidyverse/tidytemplate` entry, which stays strict either way, and there is no `Additional_repositories` field. The first two changes are insurance for the day CRAN archives something that lands in either place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hcbd7RdNjqre33JRgc86j8